### PR TITLE
Add a license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Photopea
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Photopea doesn't currently have a license, I'm proposing that the MIT license should be added to it (if people would like to suggest alternatives, then feel free!)

#45 discusses this issue, my comments on that are as follows:

Why _wouldn't_ you ( @photopea ) open-source this?

One reason would be that you're intending to make it have paid features and thus ensure that people can't legally copy it and host it elsewhere on a more free basis. Is this the case?

If that is the case, then it is possible to open-source the software and still monetise it, you might like to read [this Wikipedia article on the matter](https://en.wikipedia.org/wiki/Business_models_for_open-source_software)! It may still be possible to open-source the software :) If you're not looking to make money from this software, then I don't see _any_ reason to not open-source it!

> Photopea may have bugs and I can not guarantee anything.

Part of the MIT licenses (and most open-source licenses are as follows):

> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
> SOFTWARE.

You provide the software without any warranty as the license says, you do not guarantee anything with this license!

Merging this pull request, and then adding the full code (client-side and server-side, probably in different repositories) would allow people to contribute to the software and would also allow them to make their own website based on this software, if they so wish!

If you'd like to read more about licenses then please read https://choosealicense.com/ which is a website made by GitHub! On the ['No License' page](https://choosealicense.com/no-permission/), it says

> Ask the maintainers nicely to add a license. Unless the software includes strong indications to the contrary, lack of a license is probably an oversight. If the software is hosted on a site like GitHub, open an issue requesting a license and include a link to this site. If you’re bold and it’s fairly obvious what license is most appropriate, open a pull request to add a license – see “suggest this license” in the sidebar of the page for each license on this site (e.g., MIT).

So that's what I'm doing! :)

MIT would allow people to fork your software and make a proprietary version that they may make money from, GPLv3 would stop people from making proprietary versions, but they could find a way to monetise their open-source version that you didn't.